### PR TITLE
Display two day event as single long event instead of two separate

### DIFF
--- a/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/VCalendar.java
+++ b/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/VCalendar.java
@@ -338,8 +338,7 @@ public class VCalendar extends Composite implements VHasDropHandler {
                         itemMoving = sdc.getMoveItem() != null;
                     }
 
-                    long d = e.getRangeInMilliseconds();
-                    if ((d > 0 && d <= DateConstants.DAYINMILLIS)
+                    if (e.isSingleDay()
                             && !e.isAllDay()) {
                         timeCells.add(sdc);
                     } else {

--- a/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/CalendarItem.java
+++ b/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/CalendarItem.java
@@ -307,6 +307,19 @@ public class CalendarItem {
     }
 
     /**
+     * Answers whether the start of the event and end of the event is within
+     * the same day. 
+     *
+     * @return true if start and end are in the same day, false otherwise
+     */
+    @SuppressWarnings("deprecation")
+    public boolean isSingleDay() {
+        Date start = getStart();
+        Date end = getEnd();
+        return start.getYear() == end.getYear() && start.getMonth() == end.getMonth() && start.getDate() == end.getDate();
+    }
+
+    /**
      * Get the amount of minutes for the event on a specific day. This is useful
      * if the event spans several days.
      *

--- a/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/SimpleDayCell.java
+++ b/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/SimpleDayCell.java
@@ -281,7 +281,7 @@ public class SimpleDayCell extends FocusableFlowPanel implements MouseUpHandler,
         eventDiv.setItemIndex(item.getIndex());
         eventDiv.setCalendarItem(item);
 
-        if (item.getRangeInMilliseconds() <= DateConstants.DAYINMILLIS && !item.isAllDay()) {
+        if (item.isSingleDay() && !item.isAllDay()) {
 
             if (item.getStyleName() != null) {
                 eventDiv.addStyleDependentName(item.getStyleName());


### PR DESCRIPTION
When the event spans two days (even if it's shorter than a day), the event should
be displayed as one long event in the month view instead of two separate events.