### PR TITLE
Add style names for weekend days on Month and Week views

### DIFF
--- a/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/VCalendar.java
+++ b/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/VCalendar.java
@@ -15,6 +15,7 @@
  */
 package org.vaadin.addon.calendar.client.ui;
 
+import java.time.DayOfWeek;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -546,9 +547,9 @@ public class VCalendar extends Composite implements VHasDropHandler {
                 isToday = true;
             }
 
-            dayToolbar.add(realDayNames[dayOfWeek - 1], date, day.getLocalizedDateFormat(), isToday ? "today" : null);
+            dayToolbar.add(realDayNames[dayOfWeek - 1], date, day.getLocalizedDateFormat(), isToday ? "today" : null, isWeekendDay(dayOfWeek));
             weeklyLongEvents.addDate(date);
-            weekGrid.addDate(date, day.getStyledSlots());
+            weekGrid.addDate(date, day.getStyledSlots(), isWeekendDay(dayOfWeek));
 
             if (isToday) {
                 weekGrid.setToday(date, today);
@@ -556,6 +557,10 @@ public class VCalendar extends Composite implements VHasDropHandler {
         }
 
         dayToolbar.addNextButton();
+    }
+
+    private boolean isWeekendDay(int dayOfWeek) {
+        return dayOfWeek == DayOfWeek.SATURDAY.getValue() || dayOfWeek == DayOfWeek.SUNDAY.getValue();
     }
 
     /**
@@ -625,6 +630,10 @@ public class VCalendar extends Composite implements VHasDropHandler {
                 cell.addStyleDependentName("prev-month");
             } else if (lastDayFound) {
                 cell.addStyleDependentName("next-month");
+            };
+
+            if (isWeekendDay(dayOfWeek)) {
+                cell.addStyleDependentName("weekend");
             }
 
             if (dayOfMonth >= 1 && !monthNameDrawn) {

--- a/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/DateCell.java
+++ b/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/DateCell.java
@@ -102,7 +102,7 @@ public class DateCell extends FocusableComplexPanel
         }
     }
 
-    public DateCell(WeekGrid parent, Date date, Map<Long, CalTimeSlot> timeSlotStyles) {
+    public DateCell(WeekGrid parent, Date date, Map<Long, CalTimeSlot> timeSlotStyles, boolean isWeekendDay) {
         weekgrid = parent;
         Element mainElement = DOM.createDiv();
         setElement(mainElement);
@@ -110,6 +110,9 @@ public class DateCell extends FocusableComplexPanel
         setDate(date);
 
         addStyleName("v-calendar-day-times");
+        if (isWeekendDay) {
+            addStyleName("v-calendar-weekend-day-times");
+        }
 
         handlers = new LinkedList<>();
 

--- a/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/DayToolbar.java
+++ b/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/DayToolbar.java
@@ -93,13 +93,17 @@ public class DayToolbar extends HorizontalPanel implements ClickHandler {
         }
     }
 
-    public void add(String dayName, final Date date, String localized_date_format, String extraClass) {
+    public void add(String dayName, final Date date, String localized_date_format, String extraClass, boolean isWeekendDay) {
 
         HTML l = new HTML(("<span>" + dayName + "</span> " + localized_date_format).trim());
         l.setStylePrimaryName("v-calendar-header-day");
 
         if (extraClass != null) {
             l.addStyleDependentName(extraClass);
+        }
+
+        if (isWeekendDay) {
+            l.addStyleDependentName("weekend");
         }
 
         if (verticalSized) {

--- a/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/WeekGrid.java
+++ b/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/WeekGrid.java
@@ -124,8 +124,8 @@ public class WeekGrid extends SimplePanel {
         return width;
     }
 
-    public void addDate(Date d, Map<Long, CalTimeSlot> timeSlotStyles) {
-        final DateCell dc = new DateCell(this, d, timeSlotStyles);
+    public void addDate(Date d, Map<Long, CalTimeSlot> timeSlotStyles, boolean isWeekendDay) {
+        final DateCell dc = new DateCell(this, d, timeSlotStyles, isWeekendDay);
         dc.setDisabled(isDisabled());
         dc.setHorizontalSized(isHorizontalScrollable() || width < 0);
         dc.setVerticalSized(isVerticalScrollable());


### PR DESCRIPTION
Added attachment of style names for weekend days on Month and Week views.
This should allow definition of custom styling for weekend days on these views.

The new styles (including the prefix tags that are added automatically in some cases):
v-calendar-month-day-weekend (for weekend days on Month view)
v-calendar-header-day-weekend (for weekend day headers on Week view)
v-calendar-weekend-day-times (for weekend day bodies on Week view)